### PR TITLE
fix(*): enable TLS for NATS connections with credentials

### DIFF
--- a/src/main/java/io/kestra/plugin/nats/NatsConnection.java
+++ b/src/main/java/io/kestra/plugin/nats/NatsConnection.java
@@ -17,6 +17,7 @@ import lombok.experimental.SuperBuilder;
 import java.io.File;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
+import java.security.NoSuchAlgorithmException;
 
 @SuperBuilder
 @ToString
@@ -34,7 +35,7 @@ public abstract class NatsConnection extends Task implements NatsConnectionInter
 
     protected Property<String> creds;
 
-    protected Connection connect(RunContext runContext) throws IOException, InterruptedException, IllegalVariableEvaluationException {
+    protected Connection connect(RunContext runContext) throws IOException, InterruptedException, IllegalVariableEvaluationException, NoSuchAlgorithmException {
         Options.Builder connectOptions = Options.builder().server(runContext.render(url));
         if (username != null && password != null) {
             connectOptions.userInfo(runContext.render(username).as(String.class).orElseThrow(),
@@ -51,7 +52,7 @@ public abstract class NatsConnection extends Task implements NatsConnectionInter
                 .toFile();
 
             AuthHandler ah = Nats.credentials(credsFiles.getAbsolutePath());
-            connectOptions.authHandler(ah);
+            connectOptions.authHandler(ah).secure();
         }
 
         return Nats.connect(connectOptions.build());


### PR DESCRIPTION
Response using scaleway server

```yaml
 url: nats://nats.mnq.fr-par.scaleway.com:4222
```
<img width="1163" alt="Screenshot 2025-07-02 at 12 45 44 AM" src="https://github.com/user-attachments/assets/c5ea6c0f-54ee-496a-8c0b-145d359d6bbc" />
<img width="479" alt="Screenshot 2025-07-02 at 12 46 05 AM" src="https://github.com/user-attachments/assets/5b2f6a4f-f380-49dd-b433-751816548617" />


fixes #72 