### PR TITLE
Used the new 'ubiquitous' from in Produce.java

### DIFF
--- a/src/main/java/io/kestra/plugin/nats/Produce.java
+++ b/src/main/java/io/kestra/plugin/nats/Produce.java
@@ -119,19 +119,19 @@ public class Produce extends NatsConnection implements RunnableTask<Produce.Outp
 
     public Output run(RunContext runContext) throws Exception {
         Connection connection = connect(runContext); 
-+       int messagesCount = Data.from(this.from).read(runContext)
-+            .map(throwFunction(object -> {
-+                connection.publish(
-+                    this.producerMessage(
-+                        runContext.render(this.subject),
-+                        runContext.render((Map<String, Object>) object)
-+                    )
-+                );
-+                return 1;
-+            }))
-+            .reduce(Integer::sum)
-+            .blockOptional()
-+            .orElse(0);
+        int messagesCount = Data.from(this.from).read(runContext)
+            .map(throwFunction(object -> {
+                 connection.publish(
+                     this.producerMessage(
+                         runContext.render(this.subject),
+                         runContext.render((Map<String, Object>) object)
+                     )
+                 );
+                 return 1;
+             }))
+            .reduce(Integer::sum)
+            .blockOptional()
+            .orElse(0);
 
         connection.flushBuffer();
         connection.close();


### PR DESCRIPTION
closes https://github.com/kestra-io/kestra/issues/12350

Summary

This PR refactors the NATS Produce task to use the new Data.From interface for unified message input handling.

Affected Files

Produce.java → replaced manual parsing logic for from with Data.from(from).read(runContext).

Changes

Implemented the Data.From interface in Produce.

Simplified input reading by removing manual checks for String, List, and URI types.

Now reads all message sources (map, list, or file) through the common Data.from abstraction.

Notes

No changes to message publishing behavior — only cleaner, standardized data input handling.