### PR TITLE
fix(plugin-nats): align @PluginSubGroup titles with metadata YAML

### DIFF
--- a/src/main/java/io/kestra/plugin/nats/core/package-info.java
+++ b/src/main/java/io/kestra/plugin/nats/core/package-info.java
@@ -1,4 +1,5 @@
 @PluginSubGroup(
+    title = "NATS Core",
     description = "This subgroup of plugins contains core tasks for NATS messaging tasks and triggers.", categories = {
         PluginSubGroup.PluginCategory.DATA,
         PluginSubGroup.PluginCategory.INFRASTRUCTURE

--- a/src/main/java/io/kestra/plugin/nats/kv/package-info.java
+++ b/src/main/java/io/kestra/plugin/nats/kv/package-info.java
@@ -1,4 +1,5 @@
 @PluginSubGroup(
+    title = "NATS KV",
     description = "This sub-group of plugins contains tasks for interacting with NATS key-value stores.", categories = {
         PluginSubGroup.PluginCategory.DATA,
         PluginSubGroup.PluginCategory.INFRASTRUCTURE


### PR DESCRIPTION
## Summary

- Updates `@PluginSubGroup(title = ...)` in `package-info.java` files to match the `title` field in the corresponding subgroup metadata YAML files
- Eliminates duplicate/empty subgroup URLs on kestra.io caused by the annotation falling back to the package name when no title is set, while metadata uses a different slug

## Test plan

- [ ] Verify kestra.io subgroup pages no longer show empty duplicate routes after merge