### PR TITLE
fix(security): remediate OWASP/CWE audit findings (2026-06-30)

### DIFF
--- a/src/main/java/io/kestra/plugin/nats/core/NatsConnection.java
+++ b/src/main/java/io/kestra/plugin/nats/core/NatsConnection.java
@@ -29,15 +29,20 @@ import lombok.experimental.SuperBuilder;
 public abstract class NatsConnection extends Task implements NatsConnectionInterface {
     protected String url;
 
+    @ToString.Exclude
     @PluginProperty(secret = true, group = "connection")
     protected Property<String> username;
 
+    @ToString.Exclude
     @PluginProperty(secret = true, group = "connection")
     protected Property<String> password;
 
+    @ToString.Exclude
     @PluginProperty(secret = true, group = "connection")
     protected Property<String> token;
 
+    @ToString.Exclude
+    @PluginProperty(secret = true)
     protected Property<String> creds;
 
     protected Connection connect(RunContext runContext) throws IOException, InterruptedException, IllegalVariableEvaluationException, NoSuchAlgorithmException {

--- a/src/main/java/io/kestra/plugin/nats/core/NatsConnection.java
+++ b/src/main/java/io/kestra/plugin/nats/core/NatsConnection.java
@@ -42,7 +42,7 @@ public abstract class NatsConnection extends Task implements NatsConnectionInter
     protected Property<String> token;
 
     @ToString.Exclude
-    @PluginProperty(secret = true)
+    @PluginProperty(group = "connection", secret = true)
     protected Property<String> creds;
 
     protected Connection connect(RunContext runContext) throws IOException, InterruptedException, IllegalVariableEvaluationException, NoSuchAlgorithmException {

--- a/src/main/java/io/kestra/plugin/nats/core/NatsConnectionInterface.java
+++ b/src/main/java/io/kestra/plugin/nats/core/NatsConnectionInterface.java
@@ -38,6 +38,6 @@ public interface NatsConnectionInterface {
     @Schema(
         title = "Credentials files authentification"
     )
-    @PluginProperty(group = "advanced")
+    @PluginProperty(secret = true, group = "advanced")
     Property<String> getCreds();
 }

--- a/src/main/java/io/kestra/plugin/nats/core/RealtimeTrigger.java
+++ b/src/main/java/io/kestra/plugin/nats/core/RealtimeTrigger.java
@@ -86,12 +86,17 @@ import static io.kestra.core.utils.Rethrow.throwFunction;
 )
 public class RealtimeTrigger extends AbstractTrigger implements RealtimeTriggerInterface, TriggerOutput<Consume.NatsMessageOutput>, NatsConnectionInterface, SubscribeInterface {
     private String url;
+    @ToString.Exclude
     @PluginProperty(secret = true, group = "connection")
     private Property<String> username;
+    @ToString.Exclude
     @PluginProperty(secret = true, group = "connection")
     private Property<String> password;
+    @ToString.Exclude
     @PluginProperty(secret = true, group = "connection")
     private Property<String> token;
+    @ToString.Exclude
+    @PluginProperty(secret = true)
     private Property<String> creds;
     private String subject;
     private Property<String> durableId;

--- a/src/main/java/io/kestra/plugin/nats/core/RealtimeTrigger.java
+++ b/src/main/java/io/kestra/plugin/nats/core/RealtimeTrigger.java
@@ -96,7 +96,7 @@ public class RealtimeTrigger extends AbstractTrigger implements RealtimeTriggerI
     @PluginProperty(secret = true, group = "connection")
     private Property<String> token;
     @ToString.Exclude
-    @PluginProperty(secret = true)
+    @PluginProperty(group = "connection", secret = true)
     private Property<String> creds;
     private String subject;
     private Property<String> durableId;

--- a/src/main/java/io/kestra/plugin/nats/core/Trigger.java
+++ b/src/main/java/io/kestra/plugin/nats/core/Trigger.java
@@ -72,7 +72,7 @@ public class Trigger extends AbstractTrigger implements PollingTriggerInterface,
     @PluginProperty(secret = true, group = "connection")
     private Property<String> token;
     @ToString.Exclude
-    @PluginProperty(secret = true)
+    @PluginProperty(group = "connection", secret = true)
     private Property<String> creds;
     private String subject;
     private Property<String> durableId;

--- a/src/main/java/io/kestra/plugin/nats/core/Trigger.java
+++ b/src/main/java/io/kestra/plugin/nats/core/Trigger.java
@@ -62,12 +62,17 @@ import lombok.experimental.SuperBuilder;
 )
 public class Trigger extends AbstractTrigger implements PollingTriggerInterface, TriggerOutput<Consume.Output>, NatsConnectionInterface, ConsumeInterface, SubscribeInterface {
     private String url;
+    @ToString.Exclude
     @PluginProperty(secret = true, group = "connection")
     private Property<String> username;
+    @ToString.Exclude
     @PluginProperty(secret = true, group = "connection")
     private Property<String> password;
+    @ToString.Exclude
     @PluginProperty(secret = true, group = "connection")
     private Property<String> token;
+    @ToString.Exclude
+    @PluginProperty(secret = true)
     private Property<String> creds;
     private String subject;
     private Property<String> durableId;


### PR DESCRIPTION
## Summary

Remediates all findings (CRITICAL/HIGH/MEDIUM/LOW) from the 2026-06-30 automated security audit against OWASP Top 10 (2025), CWE Top 25, and OWASP ASVS Level 1.

## Findings Fixed

- **HIGH** — NATS creds field missing `@PluginProperty(secret=true)` — `src/main/java/io/kestra/plugin/nats/core/NatsConnection.java:41` — Added `@PluginProperty(secret = true)` to the `creds` field in `NatsConnection`, `Trigger.java:71`, and `RealtimeTrigger.java:95`, and updated the `getCreds()` getter in `NatsConnectionInterface` to include `secret = true`, so the NKey seed / JWT credential material is masked in the UI, logs, and API responses.
- **MEDIUM** — `@ToString` on credential-bearing classes without `@ToString.Exclude` on secret fields — `src/main/java/io/kestra/plugin/nats/core/NatsConnection.java:25` — Added `@ToString.Exclude` to the `username`, `password`, `token`, and `creds` fields in `NatsConnection`, `Trigger`, and `RealtimeTrigger` so Lombok's generated `toString()` no longer leaks secret values.

## Testing

- [ ] `./gradlew build` passes
- [ ] No regressions in existing tests

## References

- Security Audit EPIC: https://github.com/kestra-io/plugin-nats/issues/157
- [Full Audit Report](https://claude.ai/code/artifact/87ba8c38-c7ec-40ef-8d8e-384da1bfacf4)
- [Org-wide Security Meta-EPIC](https://github.com/kestra-io/kestra-ee/issues/9092)
